### PR TITLE
discard tx on commit/abort in case of an error too

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -1208,8 +1208,9 @@ public:
    * @post `handle() == nullptr`
    */
   void commit() {
-    lmdb::txn_commit(_handle);
+    auto h = _handle;
     _handle = nullptr;
+    lmdb::txn_commit(h);
   }
 
   /**
@@ -1218,8 +1219,9 @@ public:
    * @post `handle() == nullptr`
    */
   void abort() noexcept {
-    lmdb::txn_abort(_handle);
+    auto h = _handle;
     _handle = nullptr;
+    lmdb::txn_abort(h);
   }
 
   /**


### PR DESCRIPTION
Prevents double deallocation of tx on MDB_MAP_FULL when committing. I think this fix is semantically correct but judge for yourself. It avoids memory management issues regarding the transactions in case of an error when committing.

Our code reacts to MDB_MAP_FULL and MDB_MAP_RESIZED errors by updating the mapsize (once all tx are closed) and rescheduling the database ops. Without this fix, we have memory lifecycle issues in the LMDB code.