### PR TITLE
explicitly add <string> for std::string

### DIFF
--- a/lmdb++.h
+++ b/lmdb++.h
@@ -30,6 +30,7 @@
 #include <cstdio>      /* for std::snprintf() */
 #include <cstring>     /* for std::memcpy() */
 #include <stdexcept>   /* for std::runtime_error */
+#include <string>      /* for std::string */
 #include <string_view> /* for std::string_view */
 #include <limits>      /* for std::numeric_limits<> */
 #include <memory>      /* for std::addressof */


### PR DESCRIPTION
string_view does not include string in openbsd

Signed-off-by: Aisha Tammy <floss@bsd.ac>

---

Needed at https://github.com/hoytech/lmdbxx/blob/master/lmdb%2B%2B.h#L1281