### PR TITLE
Add meson build system support

### DIFF
--- a/check.cc
+++ b/check.cc
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <filesystem>
 
 
 int main() {
@@ -17,6 +18,9 @@ int main() {
   std::string longLivedValue;
 
   try {
+    std::filesystem::remove_all("testdb/");
+    std::filesystem::create_directories("testdb/");
+
     auto env = lmdb::env::create();
     env.set_max_dbs(64);
     env.open("testdb/", envFlags);

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,38 @@
+project(
+  'lmdbxx',
+  'cpp',
+  version : '1.0.0',
+  license: 'Unlicense',
+  default_options : ['warning_level=3', 'cpp_std=c++17']
+)
+
+lmdb_dep = dependency('lmdb')
+
+lmdbxx_dep = declare_dependency(include_directories : '.', dependencies: lmdb_dep)
+meson.override_dependency('lmdb++', lmdbxx_dep)
+
+install_headers('lmdb++.h')
+
+pkg = import('pkgconfig')
+pkg.generate(libraries: lmdbxx_dep, name: 'lmdb++', description: 'C++17 wrapper for the LMDB embedded B+ tree database library')
+
+if get_option('examples')
+  check = executable(
+    'example',
+    'example.cc',
+    dependencies: lmdbxx_dep,
+    install: false
+  )
+endif
+
+if get_option('tests')
+  check = executable(
+    'check',
+    'check.cc',
+    dependencies: lmdbxx_dep,
+    install: false
+  )
+
+  test('check', check)
+endif
+

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('tests', type : 'boolean', value : false, description : 'Build the tests')
+option('examples', type : 'boolean', value : false, description : 'Build the examples')


### PR DESCRIPTION
This enables you to build the project using:

    meson configure -Dexamples=true -Dtests=true builddir
    meson compile -C builddir

You can run the tests using:

    meson test -C builddir

And you can simply consume this project as a wrap in other meson
projects.

This also adds a pkgconfig file, so you can do
`dependency('lmdb++', version: '>=1.0.0')` in meson (or equivalent in
other projects).

(It's useful for our usage in Nheko although we can just apply it as a patch in our wrap, so if you are against adding a buildsystem, that is fine by me. I just thought I should share it!)